### PR TITLE
Bump version to v2.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/chrisgavin/paginated-go-gh
+module github.com/chrisgavin/paginated-go-gh/v2
 
 go 1.23.0
 


### PR DESCRIPTION
Bumping the version due to a new version of `go-gh`.